### PR TITLE
Tabular inline errors

### DIFF
--- a/viewsets/templates/forms/tabular_inline.html
+++ b/viewsets/templates/forms/tabular_inline.html
@@ -14,6 +14,13 @@
                 </tr>
             </thead>
             <tbody>{% for form in formset.forms %}
+                {% if form.non_field_errors %}
+                <tr>
+                    <td colspan=100>
+                        {{ form.non_field_errors }}
+                    </td>
+                </tr>
+                {% endif %}
                 <tr>{% for field in form.visible_fields %}
                     <td>
                         {% if forloop.counter == 1 %}
@@ -24,11 +31,6 @@
                         {{ field }}
                         {{ field.errors }}
                     </td>{% endfor %}
-                    {% if form.non_field_errors %}
-                    <td>
-                        {{ form.non_field_errors }}
-                    </td>
-                    {% endif %}
                 </tr>{% endfor %}
             </tbody>
         </table>

--- a/viewsets/templates/forms/tabular_inline.html
+++ b/viewsets/templates/forms/tabular_inline.html
@@ -4,7 +4,6 @@
         <h3 class="control-label">{{ title }}</h3>
     </div>
     <div class="col-lg-10">
-        {{ formset.errors }}
         {{ formset.management_form }}
         {{ formset.non_form_errors }}
         <table id="{{ inline.opts.object_name }}-inline" class="table table-striped">

--- a/viewsets/templates/forms/tabular_inline.html
+++ b/viewsets/templates/forms/tabular_inline.html
@@ -22,7 +22,13 @@
                             {% endfor %}
                         {% endif %}
                         {{ field }}
+                        {{ field.errors }}
                     </td>{% endfor %}
+                    {% if form.non_field_errors %}
+                    <td>
+                        {{ form.non_field_errors }}
+                    </td>
+                    {% endif %}
                 </tr>{% endfor %}
             </tbody>
         </table>


### PR DESCRIPTION
I just discovered that errors that would prevent form submission don't appear when the page is rendered, which will confuse users.